### PR TITLE
Added ability to change oab-java.sh url

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Attributes
 ==========
 
 * `node["java"]["jdk_version"]` - Version of JDK you would like installed (`6` or `7`), default `6`.
+* `node["java"]["oab_java_url"]` - URL to oab-java.sh script. Default value is ok.
 
 Recipes
 =======

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "wheezy64"
+  config.berkshelf.enabled = true
+
+  config.vm.provider :virtualbox do |vb|
+    # Don't boot with headless mode
+    vb.gui = false
+    #   # Use VBoxManage to customize the VM. For example to change memory:
+    vb.customize ["modifyvm", :id, "--memory", "512"]
+  end
+  
+  config.vm.hostname = "java-machine"
+
+  config.vm.provision :chef_solo do |chef|
+    chef.json = {
+      :java => {
+        :jdk_version => '7',
+        :oab_java_url => "https://raw.github.com/jsirex/oab-java6/master/oab-java.sh", #contains latest fix, TODO remove
+      }
+    }
+    chef.run_list = [
+        "recipe[java]"
+    ]
+  end
+
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,3 +16,4 @@
 # limitations under the License.
 
 default[:java][:jdk_version] = "6"
+default[:java][:oab_java_url] = "https://raw.github.com/flexiondotorg/oab-java6/master/oab-java.sh"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,10 @@
+name              "java"
 maintainer        "Henry Garner"
 maintainer_email  "henry@henrygarner.com"
 license           "Apache 2.0"
 description       "Installs Java runtime using oab-java script by Martin Wimpress (https://github.com/flexiondotorg/oab-java6)"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.0.0"
+version           "1.0.1"
 
 recipe "java", "Installs Java runtime"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,8 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+execute "apt-get-update" do
+  command "apt-get update"
+  ignore_failure true
+  not_if do ::File.exist? '/tmp/oab-java.sh' end  
+end
+
 remote_file "/tmp/oab-java.sh" do
-  source "https://raw.github.com/flexiondotorg/oab-java6/master/oab-java.sh"
+  source node[:java][:oab_java_url]
   action :create_if_missing
   mode "0755"
 end


### PR DESCRIPTION
Current version of oab-java.sh is broken. I'd already fixed issue:
https://github.com/flexiondotorg/oab-java6/issues/113

It is possible to change oab-java.sh URL, for example point it to a tag or a branch.
Added Vagrant for testing and using my fork with fix.
